### PR TITLE
Change formatting and behavior of page and blog creation modals

### DIFF
--- a/assets/scripts/blog/ui.js
+++ b/assets/scripts/blog/ui.js
@@ -10,6 +10,7 @@ const clearForm = () => {
 const createBlogSuccess = (data) => {
   console.log("Blog successfully created!", data);
   clearForm();
+  $('#create-blog-modal').modal('hide');
 };
 
 const createBlogFail = (data) => {

--- a/assets/scripts/page/ui.js
+++ b/assets/scripts/page/ui.js
@@ -10,6 +10,7 @@ const clearForm = () => {
 const createPageSuccess = (data) => {
   console.log("Page successfully created!", data);
   clearForm();
+  $('#create-page-modal').modal('hide');  
 };
 
 const createPageFail = (data) => {

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
               <label for="passwords[new]">New password</label>
               <input name="passwords[new]" id="passwords[new]" type="password" placeholder="New password">
             </div>
-            <button class="btn btn-default" type="submit">Change Password</button>
+            <button type="submit">Change Password</button>
           </form>
         </div>
       </div>
@@ -69,7 +69,7 @@
             <input name="credentials[password_confirmation]" id="credentials[password_confirmation]" type="password" placeholder="Confirm password" required>
           </div>
 
-          <button class="btn btn-default" type="submit">Sign Up</button>
+          <button type="submit">Sign Up</button>
         </form>
 
         <form id="log-in" class="log-in">
@@ -81,7 +81,7 @@
             <label for="credentials[password]">Password</label>
             <input name="credentials[password]" id="credentials[password]" type="password" placeholder="Password" required>
           </div>
-          <button class="btn btn-default" type="submit">Log In</button>
+          <button type="submit">Log In</button>
         </form>
       </div>
 
@@ -174,9 +174,6 @@
          <div class="modal-dialog" role="document">
            <div class="modal-content">
              <div class="modal-header">
-               <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                 <span aria-hidden="true">&times;</span>
-               </button>
                <h4 class="modal-title" id="create-blog-modal-header">Create blog post</h4>
              </div>
              <div class="modal-body">
@@ -184,18 +181,19 @@
                <form id="create-blog">
                  <fieldset>
                    <div class="form-group">
-                     <input type="text" class="form-control" name="blog[title]" placeholder="Blog Post Title">
+                     <input type="text" class="form-control" name="blog[author]" placeholder="author: required">
                    </div>
                    <div class="form-group">
-                     <textarea class="form-control text-editor" id="blog-entry" name="blog[content]" placeholder="New Blog Post" rows="10" cols=75> </textarea>
+                     <input type="text" class="form-control" name="blog[title]" placeholder="title: required">
                    </div>
-                   <button type="submit" class="btn btn-default pull-right" name="submit">Create post</button>
+                   <div class="form-group">
+                     <textarea class="form-control text-editor" id="blog-entry" name="blog[content]" rows="10" cols="75"> </textarea>
+                   </div>
+                   <button type="submit" class="btn btn-primary pull-right" name="submit">Create page</button>
+                   <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                  </fieldset>
                </form>
               </div>
-             <div class="modal-footer">
-               <button type="button" class="btn btn-default pull-right" data-dismiss="modal">Close</button>
-             </div>
            </div>
          </div>
        </div>
@@ -205,27 +203,23 @@
         <div class="modal-dialog" role="document">
           <div class="modal-content">
             <div class="modal-header">
-              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                 <span aria-hidden="true">&times;</span>
-              </button>
-              <h4 class="modal-title" id="create-page-modal-header">Create new page</h4>
+              <h4 class="modal-title" id="create-page-modal-header">page content</h4>
             </div>
             <div class="modal-body">
               <!-- Create new page modal body-->
               <form id="create-page">
                 <fieldset>
                   <div class="form-group">
-                    <input type="text" class="form-control" name="page[header]" placeholder="Page Header">
+                    <input type="text" class="form-control" name="page[header]" placeholder="title: required">
                   </div>
                   <div class="form-group">
-                    <textarea class="form-control text-editor" name="page[content]" placeholder="Page Content" rows="10" cols=75> </textarea>
+                    <textarea class="form-control text-editor" name="page[content]" rows="10" cols="75"> </textarea>
                   </div>
-                  <button type="submit" class="btn btn-default pull-right" name="submit">Create page</button>
+                  <button type="submit" class="btn btn-primary pull-right" name="submit">Create page</button>
+                  <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                 </fieldset>
               </form>
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-default pull-right" data-dismiss="modal">Close</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
```
removed footers and nested both "create" and "close" buttons together
changed placeholders and targeting to match new data structure and requirements
added jquery lines to hide modals after creation is complete
```
